### PR TITLE
fixed trailuser serializer in order to expand the user

### DIFF
--- a/mtbconnect/mtbconnectapi/views/trailuser.py
+++ b/mtbconnect/mtbconnectapi/views/trailuser.py
@@ -13,7 +13,7 @@ class TrailUserSerializer(serializers.HyperlinkedModelSerializer):
             view_name='trailuser',
             lookup_field='id'
         )
-        fields = ('id', 'trail_id', 'user_id')
+        fields = ('id', 'trail_id', 'user')
 
         depth = 1
 


### PR DESCRIPTION
Updated the field name in TrailUserSerializer from 'user_id' to 'user' to 100% match the TrailUser model field name, so that the depth=1 would work.