### PR TITLE
Add AWS s3 Front-end endpoint to CORS whitelist

### DIFF
--- a/mtbconnect/mtbconnect/settings.py
+++ b/mtbconnect/mtbconnect/settings.py
@@ -68,7 +68,9 @@ MIDDLEWARE = [
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:8080',
     'http://localhost:3000',
-    'http://127.0.0.1:8080'
+    'http://127.0.0.1:8080',
+    'http://127.0.0.1:8000'
+    'http://mtbconnect.s3-website.us-east-2.amazonaws.com',
 )
 
 ROOT_URLCONF = 'mtbconnect.urls'


### PR DESCRIPTION
- Updated CORS whitelist to include newly-hosted MTB Connect React Front-end from AWS s3 endpoint