### PR TITLE
Add my EC2 instance IPv4 address as an Allowed host to the app

### DIFF
--- a/mtbconnect/mtbconnect/settings.py
+++ b/mtbconnect/mtbconnect/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'wd46)+acdv#_jqkzk-9x@)xdlycq2+khuzrd5qmtb&b8euf%_3'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['18.216.29.32']
 
 
 # Application definition


### PR DESCRIPTION
- Added my EC2 instance's public IPv4 address to the list of allowed hosts in this Django app