### PR TITLE
FIXED FINALLY🤘🏻. 

### DIFF
--- a/mtbconnect/mtbconnect/settings.py
+++ b/mtbconnect/mtbconnect/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'wd46)+acdv#_jqkzk-9x@)xdlycq2+khuzrd5qmtb&b8euf%_3'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['3.18.215.253', 'api.mtb-connect.com']
+ALLOWED_HOSTS = ['127.0.0.1' ,'3.18.215.253', 'api.mtb-connect.com']
 
 
 # Application definition

--- a/mtbconnect/mtbconnect/urls.py
+++ b/mtbconnect/mtbconnect/urls.py
@@ -26,7 +26,7 @@ router.register(r'trails', Trails, 'trail')
 router.register(r'trailusers', TrailUsers, 'trailuser')
 router.register(r'friends', Friends, 'friend')
 router.register(r'users', Users, 'user')
-router.register(r'videos', Videos, 'videos')
+router.register(r'videos', Videos, 'video')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/mtbconnect/mtbconnectapi/views/video.py
+++ b/mtbconnect/mtbconnectapi/views/video.py
@@ -30,3 +30,12 @@ class Videos(ViewSet):
 
         except Exception as ex:
             return HttpResponseServerError(ex)
+
+    def list(self, request):
+        
+        videos = Video.objects.all()
+
+        serializer = VideoSerializer(
+            videos, many=True, context={'request': request})
+
+        return Response(serializer.data)


### PR DESCRIPTION
- The problem expanding that FK was in my urls.py 
- I had the endpoint AND the name params for the videos route both as 'videos'
- So changing the name param to 'video' fixed it. 
- Now the 'videos' field in TrailSerializer only matches the 'related_name' attr. of the video model's FK, and the video route's endpoint